### PR TITLE
remove non-functional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ command = "/path/to/mackerel-plugin-cuenote-srs-status -H srsXXXX.cuenote.jp -u 
 ```toml
 [plugin.metrics.cuenote-srs-status]
 command = "/path/to/mackerel-plugin-cuenote-srs-status -H srsXXXX.cuenote.jp -u xxxx -p xxxxxxxx --group-stats"
-exclude_pattern = 'bounce_unique'
 ```
 
 ## cuenote-srs-stat.queue_total
@@ -51,15 +50,3 @@ exclude_pattern = 'bounce_unique'
 - cuenote-srs-stat.queue_group.delivering.*
 - cuenote-srs-stat.queue_group.undelivered.*
 - cuenote-srs-stat.queue_group.resend.*
-- cuenote-srs-stat.queue_group.success.*
-- cuenote-srs-stat.queue_group.failure.*
-- cuenote-srs-stat.queue_group.dnsfail.*
-- cuenote-srs-stat.queue_group.exclusion.*
-- cuenote-srs-stat.queue_group.bounce_unique.*
-- cuenote-srs-stat.queue_group.canceled.*
-- cuenote-srs-stat.queue_group.expired.*
-- cuenote-srs-stat.queue_group.deferral.*
-- cuenote-srs-stat.queue_group.dnsdeferral.*
-- cuenote-srs-stat.queue_group.connfail.*
-- cuenote-srs-stat.queue_group.bounce.*
-- cuenote-srs-stat.queue_group.exception.*

--- a/lib/cuenote-srs.go
+++ b/lib/cuenote-srs.go
@@ -62,18 +62,6 @@ func (c CuenoteSrsStatPlugin) addGraphDefGroup(graphdef map[string]mp.Graphs) ma
 		"delivering",
 		"undelivered",
 		"resend",
-		"success",
-		"failure",
-		"dnsfail",
-		"exclusion",
-		"bounce_unique",
-		"canceled",
-		"expired",
-		"deferral",
-		"dnsdeferral",
-		"connfail",
-		"bounce",
-		"exception",
 	}
 	labelPrefix := strings.Title(c.MetricKeyPrefix())
 
@@ -179,7 +167,7 @@ func (c CuenoteSrsStatPlugin) parseNowTotal(body io.Reader) (map[string]float64,
 
 func (c CuenoteSrsStatPlugin) parseNowGroup(body io.Reader) (map[string]float64, error) {
 	stat := make(map[string]float64)
-	re := regexp.MustCompile(`#?(\S+)\t(\S+)\t([0-9]+)`)
+	re := regexp.MustCompile(`#?(\S+)\t(delivering|undelivered|resend)\t([0-9]+)`)
 
 	reader := bufio.NewReader(body)
 	for {
@@ -191,13 +179,11 @@ func (c CuenoteSrsStatPlugin) parseNowGroup(body io.Reader) (map[string]float64,
 		}
 
 		res := re.FindStringSubmatch(string(line))
-		if res == nil || len(res) != 4 {
-			return nil, errors.New("cannnot parse responce")
-		}
-
-		stat["queue_group."+res[2]+"."+res[1]], err = strconv.ParseFloat(res[3], 64)
-		if err != nil {
-			return nil, errors.New("cannot get values")
+		if res != nil || len(res) == 4 {
+			stat["queue_group."+res[2]+"."+res[1]], err = strconv.ParseFloat(res[3], 64)
+			if err != nil {
+				return nil, errors.New("cannot get values")
+			}
 		}
 	}
 

--- a/lib/cuenote-srs_test.go
+++ b/lib/cuenote-srs_test.go
@@ -22,7 +22,7 @@ func TestGraphDefinitionEnableGroup(t *testing.T) {
 	cuenoteSrs := CuenoteSrsStatPlugin{EnableGroupStats: true}
 
 	graphdef := cuenoteSrs.GraphDefinition()
-	if len(graphdef) != 16 {
+	if len(graphdef) != 4 {
 		t.Errorf("GetTempfilename: %d should be 16", len(graphdef))
 	}
 }
@@ -149,6 +149,4 @@ group1	delivering	0
 	assert.EqualValues(t, stat["queue_group.undelivered.group1"], 1111)
 	assert.EqualValues(t, reflect.TypeOf(stat["queue_group.resend.bounce"]).String(), "float64")
 	assert.EqualValues(t, stat["queue_group.resend.bounce"], 1212)
-	assert.EqualValues(t, reflect.TypeOf(stat["queue_group.success.relay"]).String(), "float64")
-	assert.EqualValues(t, stat["queue_group.success.relay"], 0)
 }


### PR DESCRIPTION
In the case of now_total, metrics other than derivering, underivered, and resend do not work.